### PR TITLE
Add authentication routes

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,0 +1,101 @@
+const httpStatus = require('http-status')
+const bcrypt = require('bcrypt')
+const jwt = require('jsonwebtoken')
+const User = require('../models/user.model')
+
+const register = async (req, res, next) => {
+  try {
+    const { name, email, password } = req.body
+    const existingUser = await User.findOne({ email })
+    if (existingUser) {
+      return res.status(httpStatus.BAD_REQUEST).json({
+        success: false,
+        message: 'Email already exists',
+        status: httpStatus.BAD_REQUEST
+      })
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10)
+    const user = await User.create({ name, email, password: hashedPassword })
+
+    return res.status(httpStatus.CREATED).json({
+      success: true,
+      status: httpStatus.CREATED,
+      data: {
+        id: user._id,
+        name: user.name,
+        email: user.email,
+        role: user.role
+      }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body
+    const user = await User.findOne({ email })
+    if (!user) {
+      return res.status(httpStatus.UNAUTHORIZED).json({
+        success: false,
+        message: 'Invalid credentials',
+        status: httpStatus.UNAUTHORIZED
+      })
+    }
+
+    const match = await bcrypt.compare(password, user.password)
+    if (!match) {
+      return res.status(httpStatus.UNAUTHORIZED).json({
+        success: false,
+        message: 'Invalid credentials',
+        status: httpStatus.UNAUTHORIZED
+      })
+    }
+
+    const token = jwt.sign({ id: user._id, role: user.role }, process.env.JWT_SECRET || 'secret', {
+      expiresIn: '1h'
+    })
+
+    return res.status(httpStatus.OK).json({
+      success: true,
+      status: httpStatus.OK,
+      data: { token }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+const createUser = async (req, res, next) => {
+  try {
+    const { name, email, password, role } = req.body
+    const existingUser = await User.findOne({ email })
+    if (existingUser) {
+      return res.status(httpStatus.BAD_REQUEST).json({
+        success: false,
+        message: 'Email already exists',
+        status: httpStatus.BAD_REQUEST
+      })
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10)
+    const user = await User.create({ name, email, password: hashedPassword, role })
+
+    return res.status(httpStatus.CREATED).json({
+      success: true,
+      status: httpStatus.CREATED,
+      data: {
+        id: user._id,
+        name: user.name,
+        email: user.email,
+        role: user.role
+      }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+module.exports = { register, login, createUser }

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose')
+
+const userSchema = new mongoose.Schema({
+  name: { type: String },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: { type: String, default: 'user' }
+}, { timestamps: true })
+
+module.exports = mongoose.model('User', userSchema)

--- a/routes/auth.routes.js
+++ b/routes/auth.routes.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const authController = require('../controllers/auth.controller')
+
+const router = express.Router()
+
+router.post('/register', authController.register)
+router.post('/login', authController.login)
+router.post('/create', authController.createUser)
+
+module.exports = router

--- a/routes/v1/index.js
+++ b/routes/v1/index.js
@@ -1,10 +1,12 @@
 const express = require('express')
 const healthRoute = require('./health.route')
 const helloWorldRoute = require('./helloworld.route')
+const authRoute = require('../auth.routes')
 
 const router = express.Router()
 
 router.use('/health', healthRoute)
 router.use('/', helloWorldRoute)
+router.use('/auth', authRoute)
 
 module.exports = router


### PR DESCRIPTION
## Summary
- add Mongoose user model
- implement controller for register/login/create user with bcrypt and JWT
- expose new routes for auth operations
- mount auth router in API v1 index

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872bd9cd8f88331b6c43e17c90d5e27