### PR TITLE
Implement simple user auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ npm run lint
 npm run lint:fix
 ```
 
+### Authentication
+
+Two endpoints are available for user management:
+
+```bash
+POST /api/v1/auth/register
+POST /api/v1/auth/login
+```
+
 ### Docker
 
 ```bash

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -1,0 +1,32 @@
+const httpStatus = require('http-status')
+const authService = require('../services/auth.service')
+
+const register = async (req, res, next) => {
+  try {
+    const { email, password } = req.body
+    const user = await authService.registerUser(email, password)
+    return res.status(httpStatus.CREATED).json({
+      success: true,
+      status: httpStatus.CREATED,
+      data: { id: user._id, email: user.email }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+const login = async (req, res, next) => {
+  try {
+    const { email, password } = req.body
+    const user = await authService.loginUser(email, password)
+    return res.status(httpStatus.OK).json({
+      success: true,
+      status: httpStatus.OK,
+      data: { id: user._id, email: user.email }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+module.exports = { register, login }

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose')
+
+const userSchema = new mongoose.Schema({
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  createdAt: { type: Date, default: Date.now }
+})
+
+module.exports = mongoose.model('User', userSchema)

--- a/routes/v1/auth.route.js
+++ b/routes/v1/auth.route.js
@@ -1,0 +1,9 @@
+const express = require('express')
+const authController = require('../../controllers/auth.controller')
+
+const router = express.Router()
+
+router.post('/register', authController.register)
+router.post('/login', authController.login)
+
+module.exports = router

--- a/routes/v1/index.js
+++ b/routes/v1/index.js
@@ -1,10 +1,12 @@
 const express = require('express')
 const healthRoute = require('./health.route')
 const helloWorldRoute = require('./helloworld.route')
+const authRoute = require('./auth.route')
 
 const router = express.Router()
 
 router.use('/health', healthRoute)
 router.use('/', helloWorldRoute)
+router.use('/auth', authRoute)
 
 module.exports = router

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -1,0 +1,33 @@
+const crypto = require('crypto')
+const httpStatus = require('http-status')
+const User = require('../models/user.model')
+
+const hashPassword = (password) => {
+  return crypto.createHash('sha256').update(password).digest('hex')
+}
+
+const registerUser = async (email, password) => {
+  const existing = await User.findOne({ email })
+  if (existing) {
+    const err = new Error('User already exists')
+    err.statusCode = httpStatus.BAD_REQUEST
+    throw err
+  }
+  const user = await User.create({ email, password: hashPassword(password) })
+  return user
+}
+
+const loginUser = async (email, password) => {
+  const user = await User.findOne({ email })
+  if (!user || user.password !== hashPassword(password)) {
+    const err = new Error('Invalid credentials')
+    err.statusCode = httpStatus.UNAUTHORIZED
+    throw err
+  }
+  return user
+}
+
+module.exports = {
+  registerUser,
+  loginUser
+}


### PR DESCRIPTION
## Summary
- add user model and auth service
- create registration and login controllers
- route registration and login endpoints
- document new endpoints in README

## Testing
- `npm run lint` *(fails: standard not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872c19067f883319c98d256bacec096