### PR TITLE
Add program routes and user info endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ POST /api/v1/auth/register
 POST /api/v1/auth/login
 ```
 
+### Additional auth endpoint
+
+```bash
+GET /api/v1/auth/user-info/:id
+```
+
+### Programs
+
+Program related endpoints:
+
+```bash
+GET /api/v1/programs/:userId
+POST /api/v1/programs/:userId
+PUT /api/v1/programs/:userId/:programId
+```
+
 ### Docker
 
 ```bash

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -29,4 +29,18 @@ const login = async (req, res, next) => {
   }
 }
 
-module.exports = { register, login }
+const getUserInfo = async (req, res, next) => {
+  try {
+    const { id } = req.params
+    const user = await authService.getUserInfo(id)
+    return res.status(httpStatus.OK).json({
+      success: true,
+      status: httpStatus.OK,
+      data: { id: user._id, email: user.email, programs: user.programs }
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+module.exports = { register, login, getUserInfo }

--- a/controllers/program.controller.js
+++ b/controllers/program.controller.js
@@ -1,0 +1,46 @@
+const httpStatus = require('http-status')
+const programService = require('../services/program.service')
+
+const getPrograms = async (req, res, next) => {
+  try {
+    const { userId } = req.params
+    const programs = await programService.getPrograms(userId)
+    return res.status(httpStatus.OK).json({
+      success: true,
+      status: httpStatus.OK,
+      data: programs
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+const saveProgram = async (req, res, next) => {
+  try {
+    const { userId } = req.params
+    const program = await programService.saveProgram(userId, req.body)
+    return res.status(httpStatus.CREATED).json({
+      success: true,
+      status: httpStatus.CREATED,
+      data: program
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+const editProgram = async (req, res, next) => {
+  try {
+    const { userId, programId } = req.params
+    const program = await programService.editProgram(userId, programId, req.body)
+    return res.status(httpStatus.OK).json({
+      success: true,
+      status: httpStatus.OK,
+      data: program
+    })
+  } catch (err) {
+    return next(err)
+  }
+}
+
+module.exports = { getPrograms, saveProgram, editProgram }

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const path = require('path')
 const xss = require('xss-clean')
 
 const config = require('./config')
+const programService = require('./services/program.service')
 
 const app = express()
 
@@ -26,8 +27,9 @@ app.use('/api/v1', require('./routes/v1'))
 app.use(require('./routes/errors').clientErrorHandler)
 app.use(require('./routes/errors').errorHandler)
 
-mongoose.connect(config.mongoose.connectionString, config.mongoose.options).then(() => {
+mongoose.connect(config.mongoose.connectionString, config.mongoose.options).then(async () => {
   console.log('Connected to MongoDB')
+  await programService.ensureProgramsFieldForAllUsers()
   app.listen(config.port, () =>
     console.log(`App listening on port ${config.port}`)
   )

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose')
 const userSchema = new mongoose.Schema({
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  createdAt: { type: Date, default: Date.now }
+  createdAt: { type: Date, default: Date.now },
+  programs: { type: [mongoose.Schema.Types.Mixed], default: [] }
 })
 
 module.exports = mongoose.model('User', userSchema)

--- a/routes/v1/auth.route.js
+++ b/routes/v1/auth.route.js
@@ -5,5 +5,6 @@ const router = express.Router()
 
 router.post('/register', authController.register)
 router.post('/login', authController.login)
+router.get('/user-info/:id', authController.getUserInfo)
 
 module.exports = router

--- a/routes/v1/index.js
+++ b/routes/v1/index.js
@@ -2,11 +2,13 @@ const express = require('express')
 const healthRoute = require('./health.route')
 const helloWorldRoute = require('./helloworld.route')
 const authRoute = require('./auth.route')
+const programRoute = require('./program.route')
 
 const router = express.Router()
 
 router.use('/health', healthRoute)
 router.use('/', helloWorldRoute)
 router.use('/auth', authRoute)
+router.use('/programs', programRoute)
 
 module.exports = router

--- a/routes/v1/program.route.js
+++ b/routes/v1/program.route.js
@@ -1,0 +1,13 @@
+const express = require('express')
+const programController = require('../../controllers/program.controller')
+
+const router = express.Router()
+
+router.route('/:userId')
+  .get(programController.getPrograms)
+  .post(programController.saveProgram)
+
+router.route('/:userId/:programId')
+  .put(programController.editProgram)
+
+module.exports = router

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -27,7 +27,18 @@ const loginUser = async (email, password) => {
   return user
 }
 
+const getUserInfo = async (userId) => {
+  const user = await User.findById(userId)
+  if (!user) {
+    const err = new Error('User not found')
+    err.statusCode = httpStatus.NOT_FOUND
+    throw err
+  }
+  return user
+}
+
 module.exports = {
   registerUser,
-  loginUser
+  loginUser,
+  getUserInfo
 }

--- a/services/program.service.js
+++ b/services/program.service.js
@@ -1,0 +1,67 @@
+const httpStatus = require('http-status')
+const mongoose = require('mongoose')
+const User = require('../models/user.model')
+
+const ensureProgramsField = (user) => {
+  if (!Array.isArray(user.programs)) {
+    user.programs = []
+    return true
+  }
+  return false
+}
+
+const ensureProgramsFieldForAllUsers = async () => {
+  await User.updateMany({ programs: { $exists: false } }, { $set: { programs: [] } })
+}
+
+const getPrograms = async (userId) => {
+  const user = await User.findById(userId)
+  if (!user) {
+    const err = new Error('User not found')
+    err.statusCode = httpStatus.NOT_FOUND
+    throw err
+  }
+  const changed = ensureProgramsField(user)
+  if (changed) await user.save()
+  return user.programs
+}
+
+const saveProgram = async (userId, programData) => {
+  const user = await User.findById(userId)
+  if (!user) {
+    const err = new Error('User not found')
+    err.statusCode = httpStatus.NOT_FOUND
+    throw err
+  }
+  ensureProgramsField(user)
+  const program = { _id: new mongoose.Types.ObjectId(), ...programData }
+  user.programs.push(program)
+  await user.save()
+  return program
+}
+
+const editProgram = async (userId, programId, programData) => {
+  const user = await User.findById(userId)
+  if (!user) {
+    const err = new Error('User not found')
+    err.statusCode = httpStatus.NOT_FOUND
+    throw err
+  }
+  ensureProgramsField(user)
+  const index = user.programs.findIndex(p => String(p._id) === String(programId))
+  if (index === -1) {
+    const err = new Error('Program not found')
+    err.statusCode = httpStatus.NOT_FOUND
+    throw err
+  }
+  user.programs[index] = { ...user.programs[index].toObject ? user.programs[index].toObject() : user.programs[index], ...programData, _id: user.programs[index]._id }
+  await user.save()
+  return user.programs[index]
+}
+
+module.exports = {
+  getPrograms,
+  saveProgram,
+  editProgram,
+  ensureProgramsFieldForAllUsers
+}


### PR DESCRIPTION
## Summary
- add `programs` array to user model
- create service and controller for managing programs
- register `/programs` routes
- add `/auth/user-info` endpoint
- initialize programs field for all users at startup
- document new endpoints

## Testing
- `npm run lint` *(fails: standard not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68735417f67883319a1dea5723ec5e73